### PR TITLE
musescore-general-soundfont: use https instead of ftp

### DIFF
--- a/org.openttd.OpenTTD.yaml
+++ b/org.openttd.OpenTTD.yaml
@@ -40,7 +40,7 @@ modules:
       - ln -s $FLATPAK_DEST/share/sounds/sf3/{MuseScore_General,default-GM}.sf3
     sources:
       - type: file
-        url: ftp://ftp.osuosl.org/pub/musescore/soundfont/MuseScore_General/MuseScore_General.sf3
+        url: https://ftp.osuosl.org/pub/musescore/soundfont/MuseScore_General/MuseScore_General.sf3
         sha256: 5b85b6c2c61d10b2b91cddd41efcce7b25cd31c8271d511c73afafbef20b6fa3
 
   - name: lzo


### PR DESCRIPTION
fedc doesn't support the ftp protocol. Switching to http(s) will fix it.