### PR TITLE
Use shared modules for SDL2 and Libdecor, default to Wayland again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.openttd.OpenTTD.yaml
+++ b/org.openttd.OpenTTD.yaml
@@ -11,36 +11,12 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
 modules:
-  - name: SDL2
-    buildsystem: autotools
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share
-    sources:
-      - type: archive
-        url: https://www.libsdl.org/release/SDL2-2.26.1.tar.gz
-        sha256: 02537cc7ebd74071631038b237ec4bfbb3f4830ba019e569434da33f42373e04
-        x-checker-data:
-          type: anitya
-          project-id: 4779
-          stable-only: true
-          url-template: https://www.libsdl.org/release/SDL2-$version.tar.gz
-    modules:
-      - name: libdecor
-        config-opts:
-          - -Ddemo=false
-        buildsystem: meson
-        cleanup:
-          - /include
-          - /lib/pkgconfig
-        sources:
-          - type: archive
-            url: https://gitlab.gnome.org/jadahl/libdecor/uploads/81adf91d27620e20bcc5f6b9b312d768/libdecor-0.1.0.tar.xz
-            sha256: fdefa11de4bd51cb14223a97e41fdd848f01f5c5ddca9b036a0c4e3e74d9f486
+  - shared-modules/libdecor/libdecor-0.1.1.json
+  
+  - shared-modules/SDL2/SDL2-2.26.1.json
 
   - name: fluidsynth
     buildsystem: cmake


### PR DESCRIPTION
If there's a specific reason as to why the default was disabled, it can easily be disabled again; But this should make it work just fine.

Preferrably, the reason as to why Wayland was disabled would also be logged in the git commit description.