### PR TITLE
Update FluidSynth and default soundfont

### DIFF
--- a/org.openttd.OpenTTD.yaml
+++ b/org.openttd.OpenTTD.yaml
@@ -17,15 +17,15 @@ modules:
 
   - shared-modules/linux-audio/fluidsynth2.json
 
-  - name: musescore-general-soundfont
+  - name: opl3-soundfont
     buildsystem: simple
     build-commands:
-      - install -D -m 644 -t $FLATPAK_DEST/share/sounds/sf3 MuseScore_General.sf3
-      - ln -rs $FLATPAK_DEST/share/sounds/sf3/{MuseScore_General,default-GM}.sf3
+      - install -D -m 644 -t $FLATPAK_DEST/share/soundfonts OPL-3_FM_128M.sf2
+      - ln -s $FLATPAK_DEST/share/soundfonts/{OPL-3_FM_128M,default}.sf2
     sources:
       - type: file
-        url: https://ftp.osuosl.org/pub/musescore/soundfont/MuseScore_General/MuseScore_General.sf3
-        sha256: 5b85b6c2c61d10b2b91cddd41efcce7b25cd31c8271d511c73afafbef20b6fa3
+        url: https://github.com/Mindwerks/opl3-soundfont/releases/download/1.0/OPL-3_FM_128M.sf2
+        sha256: 39bff96eee3dcfbce9665e3968701b894ca2136c7d0bd580281b2bbf59e80392
 
   - name: lzo
     config-opts:

--- a/org.openttd.OpenTTD.yaml
+++ b/org.openttd.OpenTTD.yaml
@@ -15,25 +15,7 @@ finish-args:
 modules:
   - shared-modules/SDL2/SDL2-with-libdecor.json
 
-  - name: fluidsynth
-    buildsystem: cmake
-    config-opts:
-      - -DLIB_INSTALL_DIR:STRING=lib
-      - -DDEFAULT_SOUNDFONT:FILEPATH=/app/share/sounds/sf3/default-GM.sf3
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share
-    sources:
-      - type: archive
-        url: https://github.com/FluidSynth/fluidsynth/archive/v2.3.1.tar.gz
-        sha256: d734e4cf488be763cf123e5976f3154f0094815093eecdf71e0e9ae148431883
-        x-checker-data:
-          type: anitya
-          project-id: 10437
-          stable-only: true
-          url-template: https://github.com/FluidSynth/fluidsynth/archive/v$version.tar.gz
+  - shared-modules/linux-audio/fluidsynth2.json
 
   - name: musescore-general-soundfont
     buildsystem: simple


### PR DESCRIPTION
Looks like [OPL3](https://musical-artifacts.com/artifacts/15) is being recommended on the Steam [forum](https://steamcommunity.com/sharedfiles/filedetails/?id=2495736570), whilst being lighter than MuseScore.

- Use FluidSynth from shared-modules instead of maintaining our own module
- Use OPL3 as a lighter alternative SF2 soundfont than MuseScore GM