### PR TITLE
Fallback to X11 if Wayland is unavailable

### DIFF
--- a/org.openttd.OpenTTD.yaml
+++ b/org.openttd.OpenTTD.yaml
@@ -11,7 +11,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
-  - --socket=wayland
+  - --socket=fallback-x11
 modules:
   - shared-modules/SDL2/SDL2-with-libdecor.json
 


### PR DESCRIPTION
Fixes https://github.com/flathub/org.openttd.OpenTTD/issues/103

“The fallback-x11 option makes the X11 socket available only if there is no Wayland socket.”
See https://docs.flatpak.org/en/latest/flatpak-command-reference.html