### PR TITLE
Use lzo module from runtime and more

### DIFF
--- a/org.openttd.OpenTTD.metainfo.xml
+++ b/org.openttd.OpenTTD.metainfo.xml
@@ -14,7 +14,20 @@
       extending it with new features.
     </p>
   </description>
+  <url type="homepage">https://www.openttd.org</url>
+  <url type="bugtracker">https://github.com/OpenTTD/OpenTTD/issues</url>
+  <url type="vcs-browser">https://github.com/OpenTTD/OpenTTD</url>
   <launchable type="desktop-id">openttd.desktop</launchable>
+  <developer id="org.openttd">
+    <name>The OpenTTD team</name>
+  </developer>
+  <update_contact>info@openttd.org</update_contact>
+  <provides>
+    <binary>openttd</binary>
+  </provides>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-chat">intense</content_attribute>
+  </content_rating>
   <screenshots>
     <screenshot type="default">
       <image>https://www.openttd.org/screenshots/1.4-02-opengfx-1920x1200.png</image>
@@ -29,19 +42,9 @@
       <image>https://www.openttd.org/screenshots/1.9-darkuk-3.png</image>
     </screenshot>
   </screenshots>
-  <url type="homepage">https://www.openttd.org/</url>
-  <developer_name>The OpenTTD team</developer_name>
-  <update_contact>info@openttd.org</update_contact>
-  <provides>
-    <binary>openttd</binary>
-  </provides>
   <releases>
-    <release version="15.1" date="2026-01-30">
-      <description></description>
-    </release>
-    <release version="15.0" date="2026-01-02">
-      <description/>
-    </release>
+    <release version="15.1" date="2026-01-30"/>
+    <release version="15.0" date="2026-01-02"/>
     <release version="14.1" date="2024-05-03"/>
     <release version="14.0" date="2024-04-14"/>
     <release version="13.4" date="2023-08-05"/>
@@ -61,7 +64,4 @@
     <release version="1.10.1" date="2020-04-13"/>
     <release version="1.10.0" date="2020-04-01"/>
   </releases>
-  <content_rating type="oars-1.1">
-    <content_attribute id="social-chat">intense</content_attribute>
-  </content_rating>
 </component>

--- a/org.openttd.OpenTTD.yaml
+++ b/org.openttd.OpenTTD.yaml
@@ -26,25 +26,6 @@ modules:
         url: https://gitlab.com/psi29a/opl3-soundfont/-/raw/1.1/OPL-3_FM_128M.sf2
         sha256: 800887998e40507a774b70a3f6c07729d2584802eec82b35be33f393dceaee0b
 
-  - name: lzo
-    config-opts:
-      - --enable-shared
-      - --disable-static
-    cleanup:
-      - /include
-      - /lib/*.la
-      - /lib/pkgconfig
-      - /share
-    sources:
-      - type: archive
-        url: https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz
-        sha256: c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072
-        x-checker-data:
-          type: anitya
-          project-id: 1868
-          stable-only: true
-          url-template: https://www.oberhumer.com/opensource/lzo/download/lzo-$version.tar.gz
-
   - name: openttd
     config-opts:
       - -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo


### PR DESCRIPTION
### Use lzo module from runtime

Freedesktop runtime version 24.08 appears to provide the **lzo** module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

**Related manifest file**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/components/lzo.bst

**Other modules provided by the Freedesktop 24.08**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/platform.bst

---

Fixes: https://github.com/flathub/org.openttd.OpenTTD/issues/145

### Fix appdata paper cuts

Fix appdata paper cuts